### PR TITLE
(implement) audit tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,12 @@
             <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-envers</artifactId>
+        </dependency>
 
-<!--End Security Dependencies-->
+        <!--End Security Dependencies-->
 
         <!-- Local Library -->
         <dependency>

--- a/src/main/java/com/utn/ProgIII/audit/AuditRevisionEntity.java
+++ b/src/main/java/com/utn/ProgIII/audit/AuditRevisionEntity.java
@@ -1,0 +1,33 @@
+package com.utn.ProgIII.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.RevisionEntity;
+
+@Entity
+@Table(name = "revinfo")
+@RevisionEntity(AuditRevisionListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditRevisionEntity extends DefaultRevisionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rev")
+    private int id;
+
+    private Long idUser;
+}

--- a/src/main/java/com/utn/ProgIII/audit/AuditRevisionEntity.java
+++ b/src/main/java/com/utn/ProgIII/audit/AuditRevisionEntity.java
@@ -11,8 +11,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.envers.DefaultRevisionEntity;
 import org.hibernate.envers.RevisionEntity;
+import org.hibernate.envers.RevisionNumber;
+import org.hibernate.envers.RevisionTimestamp;
+
+import java.util.Date;
 
 @Entity
 @Table(name = "revinfo")
@@ -22,12 +25,16 @@ import org.hibernate.envers.RevisionEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AuditRevisionEntity extends DefaultRevisionEntity {
+public class AuditRevisionEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @RevisionNumber
     @Column(name = "rev")
     private int id;
+
+    @RevisionTimestamp
+    private Date date;
 
     private Long idUser;
 }

--- a/src/main/java/com/utn/ProgIII/audit/AuditRevisionListener.java
+++ b/src/main/java/com/utn/ProgIII/audit/AuditRevisionListener.java
@@ -1,0 +1,36 @@
+package com.utn.ProgIII.audit;
+
+import com.utn.ProgIII.repository.UserRepository;
+import org.hibernate.envers.RevisionListener;
+import org.hibernate.envers.exception.AuditException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditRevisionListener implements RevisionListener {
+
+    private static UserRepository userRepository;
+
+    @Autowired
+    public void setUserRepository(UserRepository userRepository) {
+        AuditRevisionListener.userRepository = userRepository;
+    }
+
+    @Override
+    public void newRevision(Object revisionEntity) {
+        AuditRevisionEntity auditRevisionEntity = (AuditRevisionEntity) revisionEntity;
+        try {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated()) {
+                String username = auth.getName();
+                userRepository.findByCredential_Username(username).ifPresent(user -> {
+                    auditRevisionEntity.setIdUser(user.getIdUser());
+                });
+            }
+        } catch (Exception e) {
+            throw new AuditException("Error auditando: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/utn/ProgIII/configuration/SecurityConfig.java
+++ b/src/main/java/com/utn/ProgIII/configuration/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
 
-                        .requestMatchers("/user/**").hasRole("ADMIN")
+                        .requestMatchers("/users/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/product/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.PUT, "/product/**").hasRole("MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/product/**").hasRole("MANAGER")

--- a/src/main/java/com/utn/ProgIII/model/Address/Address.java
+++ b/src/main/java/com/utn/ProgIII/model/Address/Address.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import org.hibernate.envers.Audited;
 import org.hibernate.validator.constraints.Length;
 
 @Entity
@@ -12,6 +13,7 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Audited
 public class Address {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/utn/ProgIII/model/Credential/Credential.java
+++ b/src/main/java/com/utn/ProgIII/model/Credential/Credential.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.envers.Audited;
 
 /**
  * Clase que se encarga de representar las credenciales recibidas desde el repositorio, emulando la estructura de la tabla
@@ -16,6 +17,7 @@ import lombok.*;
 @Setter
 @Entity
 @Builder
+@Audited
 public class Credential {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/utn/ProgIII/model/Product/Product.java
+++ b/src/main/java/com/utn/ProgIII/model/Product/Product.java
@@ -4,6 +4,8 @@ import com.utn.ProgIII.model.ProductSupplier.ProductSupplier;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
 
 import java.util.List;
 
@@ -15,6 +17,7 @@ import java.util.List;
 @Setter
 @ToString
 @Builder
+@Audited
 public class Product {
 
     @Id
@@ -27,6 +30,7 @@ public class Product {
 
     @OneToMany (mappedBy = "product", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
+    @NotAudited
     private List<ProductSupplier> productSuppliers;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/utn/ProgIII/model/ProductSupplier/ProductSupplier.java
+++ b/src/main/java/com/utn/ProgIII/model/ProductSupplier/ProductSupplier.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.*;
+import org.hibernate.envers.Audited;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -19,7 +20,7 @@ import java.math.RoundingMode;
 @NoArgsConstructor
 @ToString
 @Builder
-
+@Audited
 public class ProductSupplier {
 
     @Id

--- a/src/main/java/com/utn/ProgIII/model/Supplier/Supplier.java
+++ b/src/main/java/com/utn/ProgIII/model/Supplier/Supplier.java
@@ -5,6 +5,8 @@ import com.utn.ProgIII.model.ProductSupplier.ProductSupplier;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
 import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@Audited
 public class Supplier {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +31,6 @@ public class Supplier {
     @NotBlank(message = "El cuit de la compania no puede estar vacio")
     @Pattern(regexp = "^(20|23|24|27|30|33|34)-?\\d{8}-?\\d$", message = "El formato del CUIT no es valido") // como un CUIL 23-24220759-9 o 23242207599 o 23/24220759/9
     private String cuit;
-
 
     @NotBlank(message = "El numero de telefono no puede estar vacio")
     @Pattern(regexp = "^(?:(?:00)?549?)?0?(?:11|[2368]\\d)(?:(?=\\d{0,2}15)\\d{2})?\\d{8}$",
@@ -46,6 +48,7 @@ public class Supplier {
 
     @OneToMany(mappedBy = "supplier", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
+    @NotAudited
     private List<ProductSupplier> productSupplier;
 
     public Supplier(String companyname, String cuit, String phonenumber, String email, Address address) {

--- a/src/main/java/com/utn/ProgIII/model/User/User.java
+++ b/src/main/java/com/utn/ProgIII/model/User/User.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.envers.Audited;
 
 /**
  * Clase que se encarga de representar los usuarios recibidos desde el repositorio, emulando la estructura de la tabla
@@ -18,6 +19,7 @@ import lombok.*;
 @Setter
 @Entity
 @Builder
+@Audited
 public class User {
 
     @Id

--- a/src/main/java/com/utn/ProgIII/repository/UserRepository.java
+++ b/src/main/java/com/utn/ProgIII/repository/UserRepository.java
@@ -7,6 +7,7 @@ import com.utn.ProgIII.model.User.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Clase que se encarga de interactuar con el ORM y el servicio de usuarios
@@ -24,5 +25,7 @@ public interface UserRepository extends JpaRepository<User,Long> {
     List<User> findByCredential_RoleAndStatus(Role role, UserStatus userStatus);
 
     User findByCredential(Credential credential);
+
+    Optional<User> findByCredential_Username(String credentialUsername);
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=ProgIII
 
 # Credenciales de la base de datos
 
-spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC-3
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=validate
 spring.datasource.url=${DB_URL_TP}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,8 @@ spring.servlet.multipart.file-size-threshold=0
 spring.servlet.multipart.location=${java.io.tmpdir}
 spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=1MB
+
+# Envers (para tablas de auditoría)
+spring.jpa.properties.org.hibernate.envers.audit_table_suffix=_AUDIT
+spring.jpa.properties.org.hibernate.envers.revision_field_name=REVISION
+spring.jpa.properties.org.hibernate.envers.revision_type_field_name=REVISION_TYPE


### PR DESCRIPTION
Create audit tables and enable auditing for User, Credential, Product, Supplier, Address, and ProductSupplier entities. It's possible to merge this PR as it is right now, but I can also add new endpoints to check the revisions made to each entity using pagination (and their corresponding id), if you want.

Check this for extra info:

https://vladmihalcea.com/spring-data-envers/

https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/history/RevisionRepository.html
